### PR TITLE
Fix bugs in macOS implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0
+
+* Fig bug in macOS implementation: the argument string for osascript was wrapped twice in quotes so that osascript didn't interpret the arguments and completed immediately
+* Fix file extension filters on macOS 
+* Escape title of file picker dialog on macOS to allow double quotes, line breaks, and backslashes
+* Manually test implementation on macOS. It works! 🥳
+
 ## 1.0.0-dev.1
 
 * Implement picking files and directories for all three platforms: Linux, macOS, and Windows

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # File Picker Desktop
 
-[![CI Pipeline](https://github.com/philenius/flutter_file_picker_desktop/actions/workflows/main.yml/badge.svg)](https://github.com/philenius/flutter_file_picker_desktop/actions/workflows/main.yml)
-![Pub Version (including pre-releases)](https://img.shields.io/pub/v/file_picker_desktop?include_prereleases)
+<a href="https://github.com/philenius/flutter_file_picker_desktop/actions/workflows/main.yml"><img alt="CI Pipeline" src="https://github.com/philenius/flutter_file_picker_desktop/actions/workflows/main.yml/badge.svg"></a> <a href="https://pub.dev/packages/file_picker_desktop"><img src="https://img.shields.io/pub/v/file_picker_desktop"></a> <a href="https://github.com/philenius/flutter_file_picker_desktop/issues"><img src="https://img.shields.io/github/issues/philenius/flutter_file_picker_desktop"></a> <img src="https://img.shields.io/github/license/philenius/flutter_file_picker_desktop">
 
 This repository contains a Dart package that allows you to use a native file explorer on Windows, macOS, and Linux for picking files and directories.
 

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -95,17 +95,19 @@ class FilePickerMacOS extends FilePicker {
   }) {
     final arguments = ['-e'];
 
+    String argument = 'choose ';
     if (pickDirectory) {
-      arguments.add('\'choose folder');
+      argument += 'folder ';
     } else {
-      arguments.add('\'choose file of type {$fileFilter}');
+      argument += 'file of type {$fileFilter} ';
 
       if (multipleFiles) {
-        arguments.add('with multiple selections allowed');
+        argument += 'with multiple selections allowed ';
       }
     }
 
-    arguments.add('with prompt "$dialogTitle"\'');
+    argument += 'with prompt "$dialogTitle"';
+    arguments.add(argument);
 
     return arguments;
   }

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -73,15 +73,15 @@ class FilePickerMacOS extends FilePicker {
       case FileType.any:
         return '';
       case FileType.audio:
-        return '"mp3", "wav", "midi", "ogg", "aac"';
+        return '"", "mp3", "wav", "midi", "ogg", "aac"';
       case FileType.custom:
-        return '"' + allowedExtensions!.join('", "') + '"';
+        return '"", "' + allowedExtensions!.join('", "') + '"';
       case FileType.image:
-        return '"jpg", "jpeg", "bmp", "gif", "png"';
+        return '"", "jpg", "jpeg", "bmp", "gif", "png"';
       case FileType.media:
-        return '"webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv", "jpg", "jpeg", "bmp", "gif", "png"';
+        return '"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv", "jpg", "jpeg", "bmp", "gif", "png"';
       case FileType.video:
-        return '"webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv"';
+        return '"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv"';
       default:
         throw Exception('unknown file type');
     }

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -21,7 +21,7 @@ class FilePickerMacOS extends FilePicker {
       allowedExtensions,
     );
     final List<String> arguments = generateCommandLineArguments(
-      dialogTitle,
+      escapeDialogTitle(dialogTitle),
       fileFilter: fileFilter,
       multipleFiles: allowMultiple,
       pickDirectory: false,
@@ -53,7 +53,7 @@ class FilePickerMacOS extends FilePicker {
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final List<String> arguments = generateCommandLineArguments(
-      dialogTitle,
+      escapeDialogTitle(dialogTitle),
       pickDirectory: true,
     );
 
@@ -111,6 +111,11 @@ class FilePickerMacOS extends FilePicker {
 
     return arguments;
   }
+
+  String escapeDialogTitle(String dialogTitle) => dialogTitle
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
+      .replaceAll('\n', '\\\n');
 
   /// Transforms the result string (stdout) of `osascript` into a [List] of
   /// file paths.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_desktop
 description: A package that allows you to use a native file explorer on Windows, macOS, and Linux to pick a directory or one or multiple files, with extension filtering support.
-version: 1.0.0-dev.1
+version: 1.0.0
 
 repository: https://github.com/philenius/flutter_file_picker_desktop
 issue_tracker: https://github.com/philenius/flutter_file_picker_desktop/issues

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -16,24 +16,24 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('"mp3", "wav", "midi", "ogg", "aac"'),
+        equals('"", "mp3", "wav", "midi", "ogg", "aac"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.image, null),
-        equals('"jpg", "jpeg", "bmp", "gif", "png"'),
+        equals('"", "jpg", "jpeg", "bmp", "gif", "png"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.media, null),
         equals(
-          '"webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv", "jpg", "jpeg", "bmp", "gif", "png"',
+          '"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv", "jpg", "jpeg", "bmp", "gif", "png"',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.video, null),
-        equals('"webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv"'),
+        equals('"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv"'),
       );
     });
 
@@ -44,12 +44,12 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.custom, ['dart']),
-        equals('"dart"'),
+        equals('"", "dart"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.custom, ['dart', 'html']),
-        equals('"dart", "html"'),
+        equals('"", "dart", "html"'),
       );
     });
   });

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -110,7 +110,7 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals("""-e 'choose file of type {} with prompt "Select a file:"'"""),
+        equals('-e choose file of type {} with prompt "Select a file:"'),
       );
     });
 
@@ -126,7 +126,8 @@ void main() {
       expect(
         cliArguments.join(' '),
         equals(
-            """-e 'choose file of type {} with multiple selections allowed with prompt "Select files:"'"""),
+          '-e choose file of type {} with multiple selections allowed with prompt "Select files:"',
+        ),
       );
     });
 
@@ -145,7 +146,7 @@ void main() {
       expect(
         cliArguments.join(' '),
         equals(
-            """-e 'choose file of type {"dart", "yml"} with prompt "Select a file:"'"""),
+            '-e choose file of type {"dart", "yml"} with prompt "Select a file:"'),
       );
     });
 
@@ -164,7 +165,8 @@ void main() {
       expect(
         cliArguments.join(' '),
         equals(
-            """-e 'choose file of type {"html"} with multiple selections allowed with prompt "Select HTML files:"'"""),
+          '-e choose file of type {"html"} with multiple selections allowed with prompt "Select HTML files:"',
+        ),
       );
     });
 
@@ -178,7 +180,7 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals("""-e 'choose folder with prompt "Select a directory:"'"""),
+        equals('-e choose folder with prompt "Select a directory:"'),
       );
     });
   });

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -54,6 +54,48 @@ void main() {
     });
   });
 
+  group('escapeDialogTitle()', () {
+    test('should escape backslashes in the title of the dialog', () {
+      final picker = FilePickerMacOS();
+
+      final escapedTitle = picker.escapeDialogTitle(
+        'Please select files that contain a \\:',
+      );
+
+      expect(
+        escapedTitle,
+        equals(
+          'Please select files that contain a \\\\:',
+        ),
+      );
+    });
+
+    test('should escape line breaks in the title of the dialog', () {
+      final picker = FilePickerMacOS();
+
+      final escapedTitle = picker.escapeDialogTitle(
+        'Please continue reading\nafter the line break:',
+      );
+
+      expect(
+        escapedTitle,
+        equals(
+          'Please continue reading\\\nafter the line break:',
+        ),
+      );
+    });
+
+    test('should escape double quotes in the title of the dialog', () {
+      final picker = FilePickerMacOS();
+
+      final escapedTitle = picker.escapeDialogTitle(
+        'Please select a "quoted" file:',
+      );
+
+      expect(escapedTitle, equals('Please select a \\"quoted\\" file:'));
+    });
+  });
+
   group('resultStringToFilePaths()', () {
     test('should interpret the result of picking no files', () {
       final picker = FilePickerMacOS();


### PR DESCRIPTION
* The argument string for osascript was wrapped twice in quotes so that osascript didn't interpret the arguments and completed immediately.
* Fix file extension filters on macOS.
* Escape title of file picker dialog on macOS to allow double quotes, line breaks, and backslashes.
* Manually test implementation on macOS. It works! 🥳